### PR TITLE
fix pseudo element syntax

### DIFF
--- a/src/pills.scss
+++ b/src/pills.scss
@@ -28,13 +28,13 @@ $padding-width: 10px;
     margin: 0 auto;
     *zoom: 1;
 
-    &:before, &:after {
+    &::before, &::after {
         content: "";
         display: table;
         line-height: 0;
     }
 
-    &:after {
+    &::after {
         clear: both;
     }
 


### PR DESCRIPTION
> Sometimes you will see double colons (::) instead of just one (:). This is part of CSS3 and an attempt to distinguish between pseudo-classes and pseudo-elements. Most browsers support both values.

https://developer.mozilla.org/en/docs/Web/CSS/Pseudo-elements
